### PR TITLE
Release 0.18

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@
  */
 
 /** The version of this project. */
-lazy val VersionStreamSync = "0.18-SNAPSHOT"
+lazy val VersionStreamSync = "0.18"
 
 /** Definition of versions for compile-time dependencies. */
 lazy val VersionCloudFiles = "0.10"

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@
  */
 
 /** The version of this project. */
-lazy val VersionStreamSync = "0.18"
+lazy val VersionStreamSync = "0.19-SNAPSHOT"
 
 /** Definition of versions for compile-time dependencies. */
 lazy val VersionCloudFiles = "0.10"


### PR DESCRIPTION
This PR adds a tag for version 0.18 and switches to version 0.19-SNAPSHOT.