### PR TITLE
Switch IDP configuration storage format to JSON 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@
  */
 
 /** The version of this project. */
-lazy val VersionStreamSync = "0.19-SNAPSHOT"
+lazy val VersionStreamSync = "0.19"
 
 /** Definition of versions for compile-time dependencies. */
 lazy val VersionCloudFiles = "0.10"

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ lazy val VersionPekkoHttp = "1.2.0"
 lazy val VersionScala = "3.7.1"
 lazy val VersionScalaXml = "2.4.0"
 lazy val VersionScli = "1.1.0"
+lazy val VersionSprayJson = "1.3.6"
 
 /** Definition of versions for test dependencies. */
 lazy val VersionScalaTest = "3.2.19"
@@ -86,6 +87,7 @@ lazy val StreamSync = (project in file("."))
     libraryDependencies ++= akkaDependencies,
     libraryDependencies += ("com.github.oheger" %% "scli" % VersionScli).cross(CrossVersion.for3Use2_13),
     libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % VersionScalaXml,
+    libraryDependencies += "io.spray" %%  "spray-json" % VersionSprayJson,
     libraryDependencies ++= cloudFilesDependencies,
     libraryDependencies ++= loggingDependencies,
     libraryDependencies ++= testDependencies,

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@
  */
 
 /** The version of this project. */
-lazy val VersionStreamSync = "0.19"
+lazy val VersionStreamSync = "0.20-SNAPSHOT"
 
 /** Definition of versions for compile-time dependencies. */
 lazy val VersionCloudFiles = "0.10"

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,6 @@ lazy val VersionLog4j = "2.25.0"
 lazy val VersionPekko = "1.1.4"
 lazy val VersionPekkoHttp = "1.2.0"
 lazy val VersionScala = "3.7.1"
-lazy val VersionScalaXml = "2.4.0"
 lazy val VersionScli = "1.1.0"
 lazy val VersionSprayJson = "1.3.6"
 
@@ -71,8 +70,8 @@ lazy val loggingDependencies = Seq(
 )
 
 lazy val testDependencies = Seq(
-  "org.scalatest" %% "scalatest" % VersionScalaTest % Test exclude("org.scala-lang.modules", "scala-xml_3"),
-  "org.scalatestplus" %% "mockito-5-12" % VersionScalaTestMockito % Test exclude("org.scala-lang.modules", "scala-xml_3"),
+  "org.scalatest" %% "scalatest" % VersionScalaTest % Test,
+  "org.scalatestplus" %% "mockito-5-12" % VersionScalaTestMockito % Test,
   "org.apache.pekko" %% "pekko-testkit" % VersionPekko % Test,
   "org.apache.pekko" %% "pekko-actor-testkit-typed" % VersionPekko % Test,
   "org.wiremock" % "wiremock" % VersionWireMock % Test
@@ -86,7 +85,6 @@ lazy val StreamSync = (project in file("."))
     scalaVersion := VersionScala,
     libraryDependencies ++= akkaDependencies,
     libraryDependencies += ("com.github.oheger" %% "scli" % VersionScli).cross(CrossVersion.for3Use2_13),
-    libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % VersionScalaXml,
     libraryDependencies += "io.spray" %%  "spray-json" % VersionSprayJson,
     libraryDependencies ++= cloudFilesDependencies,
     libraryDependencies ++= loggingDependencies,

--- a/src/integrationTest/scala/com/github/sync/cli/oauth/OAuthSpec.scala
+++ b/src/integrationTest/scala/com/github/sync/cli/oauth/OAuthSpec.scala
@@ -16,22 +16,23 @@
 
 package com.github.sync.cli.oauth
 
-import java.io.ByteArrayOutputStream
-import java.nio.file.Files
-import java.util.Locale
 import com.github.scli.DefaultConsoleReader
+import com.github.sync.FileTestHelper
 import com.github.sync.cli.CliActorSystemLifeCycle
 import com.github.sync.cli.oauth.OAuthParameterManager.LoginCommandConfig
 import com.github.sync.oauth.{OAuthStorageServiceImpl, OAuthTokenRetrieverServiceImpl, SyncOAuthStorageConfig}
-import com.github.sync.{AsyncTestHelper, FileTestHelper}
 import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers.{any, eq => argEq}
-import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers.{any, eq as argEq}
+import org.mockito.Mockito.*
 import org.scalatest.BeforeAndAfterEach
+import org.scalatest.Inspectors.forEvery
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
+import java.io.ByteArrayOutputStream
+import java.nio.file.Files
+import java.util.Locale
 import scala.concurrent.Future
 
 /**
@@ -41,8 +42,7 @@ import scala.concurrent.Future
   * unknown commands. This is achieved by directly invoking the ''main()''
   * function. Thus, only black-box testing is possible.
   */
-class OAuthSpec extends AnyFlatSpec with BeforeAndAfterEach with Matchers with FileTestHelper with MockitoSugar
-  with AsyncTestHelper:
+class OAuthSpec extends AnyFlatSpec with BeforeAndAfterEach with Matchers with FileTestHelper with MockitoSugar:
   override protected def afterEach(): Unit =
     tearDownTestFile()
     super.afterEach()
@@ -102,7 +102,7 @@ class OAuthSpec extends AnyFlatSpec with BeforeAndAfterEach with Matchers with F
 
     val output = runAndCaptureOut(args)
     output should include("success")
-    List(".xml", ".sec") foreach { ext =>
+    forEvery(List(".json", ".sec")) { ext =>
       val idpFile = testDirectory.resolve(IdpName + ext)
       Files.exists(idpFile) shouldBe true
     }


### PR DESCRIPTION
This PR changes the format in which the configuration of the IDP is stored from XML to JSON. It also tags the version 0.19 containing this change.