### PR TITLE
MirrorStage: Fixed a bug in comparing sync elements.

### DIFF
--- a/src/main/scala/com/github/sync/stream/MirrorStage.scala
+++ b/src/main/scala/com/github/sync/stream/MirrorStage.scala
@@ -266,12 +266,15 @@ private object MirrorStage:
       * @return the result of the comparison
       */
     private def compareElements(elemSource: FsElement, elemDest: FsElement): Int =
-      val (srcParent, srcName) = UriEncodingHelper.splitParent(elemSource.relativeUri)
-      val (dstParent, dstName) = UriEncodingHelper.splitParent(elemDest.relativeUri)
-      val deltaParent = srcParent.compareTo(dstParent)
-      if deltaParent != 0 then deltaParent
-      else srcName.compareTo(dstName)
-
+      val deltaLevel = elemSource.level - elemDest.level
+      if deltaLevel != 0 then
+        deltaLevel
+      else
+        val (srcParent, srcName) = UriEncodingHelper.splitParent(elemSource.relativeUri)
+        val (dstParent, dstName) = UriEncodingHelper.splitParent(elemDest.relativeUri)
+        val deltaParent = srcParent.compareTo(dstParent)
+        if deltaParent != 0 then deltaParent
+        else srcName.compareTo(dstName)
   end MirrorStageLogic
 
 /**


### PR DESCRIPTION
The mirror stage produced invalid sync operations if the last element on a processing level was removed. In this case, no action to remove this element was created, but actions to create the elements that were following in the source structure. This has been fixed by adapting the comparison of elements to include the current level.